### PR TITLE
[chore] update telegram-bot-api to 7.4.4

### DIFF
--- a/telegram-assistant.cabal
+++ b/telegram-assistant.cabal
@@ -30,7 +30,7 @@ library
     , exceptions
     , hackage-db
     , hoogle
-    , telegram-bot-api     ==7.3.1
+    , telegram-bot-api     ==7.4.4
     , telegram-bot-simple
     , text
 


### PR DESCRIPTION
Build failed with 7.3.1 version.

![telegram-cloud-photo-size-2-5449683934184075554-y](https://github.com/user-attachments/assets/9e8434d4-f9fb-4b7c-a04c-7e666627600f)
